### PR TITLE
URL encode code to prevent syntax errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "inline-esm-worker",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.1",
+      "version": "0.0.3",
       "license": "GPL-3.0-only",
       "devDependencies": {
         "ava": "3.15.0"

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,14 +1,16 @@
 //@format
 import { Worker } from "worker_threads";
-import { once } from "events";
 import process from "process";
 
 export default function run(code) {
   return new Promise(async (resolve, reject) => {
-    const worker = new Worker(new URL(`data:text/javascript,${code}`), {
-      stdout: true,
-      execArgv: [...process.execArgv, "--unhandled-rejections=strict"]
-    });
+    const worker = new Worker(
+      new URL(`data:text/javascript,${encodeURIComponent(code)}`),
+      {
+        stdout: true,
+        execArgv: [...process.execArgv, "--unhandled-rejections=strict"],
+      }
+    );
 
     worker.on("error", reject);
 

--- a/test/index_test.mjs
+++ b/test/index_test.mjs
@@ -29,3 +29,26 @@ test("if errors are thrown and caught by the worker", async t => {
     async () => await run(`throw new Error("something went wrong")`)
   );
 });
+
+test('if iife can have a comment', async t => {
+  const msg = 'Printed from inside async IIFE'
+  const fn = `
+    (async () => {
+      // Prints to terminal
+      /* Logs to console */
+      console.log('${msg}')
+    })()
+  `
+  const actual = await run(fn);
+  t.is(msg, actual.toString().trim());
+})
+
+test('if es6 modules can be imported', async t => {
+  const msg = 'ES6 style import works'
+  const fn = `
+    import fs from 'fs'
+    console.log('${msg}')
+  `
+  const actual = await run(fn);
+  t.is(msg, actual.toString().trim());
+})


### PR DESCRIPTION
Resolves TimDaub/test-readme-md#2

- URL encode code to prevent syntax errors
- Added two test cases
  - test if we can comment inside anonymous functions
  - test if we can import es6 style modules